### PR TITLE
Fixed CI failing with Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,7 @@ jobs:
       run: |
         inv build --install
 
-    - if: runner.os == 'Linux'
-      name: Run the tests on Linux
+    - name: Run the tests 
       shell:  micromamba-shell {0}
       run: |
         pytest -v 
-        
-    - if: runner.os == 'macOS'
-      name: Run the tests on macOS
-      shell:  micromamba-shell {0}
-      run: |
-        pytest -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         cache-environment: true
         post-cleanup: 'all'
 
-    -if: runner.os == 'Linux'
-      name: Setup xvfb (Linux)
+    -name: Setup xvfb (Linux)
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
         sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
         cache-environment: true
         post-cleanup: 'all'
 
-    -name: Setup xvfb (Linux)
-      if: runner.os == 'Linux'
+    - if: runner.os == 'Linux'
+      name: Setup xvfb (Linux)
       run: |
         sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
         sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         build-type: [Release]
+    env:
+      DISPLAY: ":99.0"
 
     steps:
     - uses: actions/checkout@v4
@@ -25,6 +27,13 @@ jobs:
         cache-environment: true
         post-cleanup: 'all'
 
+    -if: runner.os == 'Linux'
+      name: Setup xvfb (Linux)
+      run: |
+        sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libxcb-shape0 libglib2.0-0 libgl1-mesa-dev
+        sudo apt-get install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
+        sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
+
     - name: Install the package
       shell: micromamba-shell {0}
       run: |
@@ -34,7 +43,7 @@ jobs:
       name: Run the tests on Linux
       shell:  micromamba-shell {0}
       run: |
-        pytest -v -k "not plotter_simple"
+        pytest -v 
         
     - if: runner.os == 'macOS'
       name: Run the tests on macOS


### PR DESCRIPTION
On my local Archlinux machine, all the tests worked. However, it turns out that on the CI, for Linux, you also need to install `xvfb` and some more packages. Then `pytest` works. The hacky workaround of skipping the problematic test is no longer required