### PR TITLE
Refactor: Changes to the RendererRepresentation class and type hinting

### DIFF
--- a/examples/hydrogen_bond_with_labels/hbond.py
+++ b/examples/hydrogen_bond_with_labels/hbond.py
@@ -1,11 +1,6 @@
-from ase import Atom, Atoms
 from ase.data import chemical_symbols
-from ase.io import lammpsdata, read
-import numpy as np
-from scipy.spatial import ConvexHull
+from ase.io import read
 from pathlib import Path
-from pyvista import PolyData
-import pyvista as pv
 
 import solvis
 from solvis.visualization import AtomicPlotter

--- a/examples/hydrogen_bond_with_labels/hbond.py
+++ b/examples/hydrogen_bond_with_labels/hbond.py
@@ -123,7 +123,7 @@ solvis.vis_initializers.populate_plotter_from_solv_shell(
 )
 # Add a description of the image
 pl_render.plotter.add_text(
-    "D-A <= 3.1 Angstrom; angle HDA <=30",
+    "D-A <= 3.3 Angstrom; angle HDA <=30",
     position="upper_left",
     font_size=186,
     color="black",

--- a/examples/render_capped_trigonal_prism/render_ctp.py
+++ b/examples/render_capped_trigonal_prism/render_ctp.py
@@ -65,7 +65,7 @@ solvis.vis_initializers.fill_render_rep_atoms_from_solv_shell(
 )
 
 # Change the color of the seventh atom
-seventh_mol_name = list(render_rep.atoms.keys())[-1]
+seventh_mol_name = render_rep.atoms.atoms[-1].name
 render_rep.update_atom_color(seventh_mol_name, color=seventh_neigh_color)
 
 # Add the edges as bonds (edges are wrt convex_hull here, with the same order as atoms in solvation_shell)

--- a/examples/render_capped_trigonal_prism/render_ctp.py
+++ b/examples/render_capped_trigonal_prism/render_ctp.py
@@ -1,10 +1,5 @@
-from ase import Atom, Atoms
-from ase.data import chemical_symbols
-from ase.io import lammpsdata, read
-import numpy as np
-from scipy.spatial import ConvexHull
+from ase.io import read
 from pathlib import Path
-from pyvista import PolyData
 
 import solvis
 from solvis.visualization import AtomicPlotter

--- a/examples/render_hydrogen_bonds_octahedral/octahedral.py
+++ b/examples/render_hydrogen_bonds_octahedral/octahedral.py
@@ -1,12 +1,6 @@
-from ase import Atom, Atoms
 from ase.data import chemical_symbols
-from ase.io import lammpsdata, read
-import numpy as np
-from scipy.spatial import ConvexHull
+from ase.io import read
 from pathlib import Path
-from pyvista import PolyData
-import pyvista as pv
-import math
 
 import solvis
 from solvis.visualization import AtomicPlotter
@@ -122,7 +116,7 @@ seventh_mol_name = render_rep.get_atom_name_from_tag(target_atom_tag=seventh_mol
 render_rep.update_atom_color(seventh_mol_name, color=seventh_neigh_color)
 
 # Add bonds from the center to the solvent atoms
-bond1_render_opt = render_rep.bond_type_rendering[1].get("render_options")
+bond1_render_opt = render_rep.bond_type_rendering[1].render_options
 for solv_atom in solvation_shell.atoms:
     if solv_atom.number == o_type:
         iatom_tag = solv_atom.tag

--- a/examples/render_solvation_center/render_solvation_center.py
+++ b/examples/render_solvation_center/render_solvation_center.py
@@ -1,10 +1,6 @@
-from ase import Atom, Atoms
 from ase.data import chemical_symbols
-from ase.io import lammpsdata, read
-import numpy as np
-from scipy.spatial import ConvexHull
+from ase.io import read
 from pathlib import Path
-from pyvista import PolyData
 
 import solvis
 from solvis.visualization import AtomicPlotter
@@ -86,7 +82,7 @@ solvis.vis_initializers.fill_render_rep_atoms_from_solv_shell(
 )
 
 # Change the color of the seventh atom
-seventh_mol_name = list(render_rep.atoms.keys())[-1]
+seventh_mol_name = render_rep.atoms.atoms[-1].name
 render_rep.update_atom_color(seventh_mol_name, color=seventh_neigh_color)
 
 # Add bonds from the center to the solvent atoms

--- a/examples/single_sphericity_calc/calc_sph.py
+++ b/examples/single_sphericity_calc/calc_sph.py
@@ -1,10 +1,6 @@
-from ase import Atom, Atoms
 from ase.data import chemical_symbols
-from ase.io import lammpsdata, read
-import numpy as np
-from scipy.spatial import ConvexHull
+from ase.io import read
 from pathlib import Path
-from pyvista import PolyData
 
 import solvis
 

--- a/examples/sphericity_calc_traj/calc_sph_multiple.py
+++ b/examples/sphericity_calc_traj/calc_sph_multiple.py
@@ -1,12 +1,9 @@
 import pandas as pd
-from ase import Atom, Atoms
 from ase.data import chemical_symbols
-from ase.io import lammpsdata, read
+from ase.io import read
 import numpy as np
-from scipy.spatial import ConvexHull
 from scipy.stats import sem
 from pathlib import Path
-from pyvista import PolyData
 
 import solvis
 
@@ -103,9 +100,7 @@ for iframe, currentframe in enumerate(traj):
         df.loc[iframe, f"r6{j_ion}"] = r6_val  # distance of 6 closest neighbours
         df.loc[iframe, f"cn{j_ion}"] = cn_val
 
-df.to_csv(
-    output_file, index=False, header=True, mode="w", line_terminator="\n", sep=" "
-)
+df.to_csv(output_file, index=False, header=True, mode="w", sep=" ")
 
 # Filter non-octahedral and octahedral data
 # Octahedral if sph >= 0.836694

--- a/solvis/atom_tag_manager.py
+++ b/solvis/atom_tag_manager.py
@@ -2,31 +2,50 @@ from ase import Atoms
 
 
 class AtomTagManager:
-    def __init__(self, atoms):
+    def __init__(self, atoms: Atoms):
+
         self.tag_index_mapping = self._create_tag_index_mapping(atoms)
 
-    def _create_tag_index_mapping(self, atoms):
-        """
-        Create a dictionary mapping tags to indices and vice versa in the Atoms object.
+    def _create_tag_index_mapping(self, atoms: Atoms) -> dict[int, int]:
+        """Create a dictionary mapping tags to indices and vice versa in the Atoms object.
+
+        Args:
+            atoms (Atoms): The ASE atoms object
+
+        Returns:
+            dict[int, int]: Key: tag, value: index
         """
         return {atom.tag: (index, atom.tag) for index, atom in enumerate(atoms)}
 
-    def update_tag_index_mapping(self, atoms):
-        """
-        Update the dictionary mapping tags to indices and vice versa based on the order of Atom objects in the Atoms object.
+    def update_tag_index_mapping(self, atoms: Atoms) -> None:
+        """Update the dictionary mapping tags to indices and vice versa based on the order of Atom objects in the Atoms object.
+
+        Args:
+            atoms (Atoms): The ASE Atoms object
         """
         self.tag_index_mapping = {
             atom.tag: (index, atom.tag) for index, atom in enumerate(atoms)
         }
 
-    def lookup_index_by_tag(self, tag):
+    def lookup_index_by_tag(self, tag: int) -> int:
+        """Look up the index of the Atom object with the specified tag.
+
+        Args:
+            tag (int): Desired tag
+
+        Returns:
+            int: Index corresponding to the input tag
         """
-        Look up the index of the Atom object with the specified tag.
-        """
+
         return self.tag_index_mapping.get(tag, (None, None))[0]
 
-    def lookup_tag_by_index(self, index):
-        """
-        Look up the tag of the Atom object at the specified index.
+    def lookup_tag_by_index(self, index: int) -> int:
+        """Look up the tag of the Atom object at the specified index.
+
+        Args:
+            index (int): index for which you want the tag
+
+        Returns:
+            int: tag corresponding to the input index
         """
         return self.tag_index_mapping.get(index, (None, None))[1]

--- a/solvis/bond_helper.py
+++ b/solvis/bond_helper.py
@@ -1,6 +1,9 @@
 from ase import Atom, Atoms
 from ase.data import chemical_symbols
+from typing import Any
 import math
+
+from solvis.solvation_shell import SolvationShell
 from .util import (
     k_nearest_neighbours,
     minimum_image_distance,
@@ -9,7 +12,20 @@ from .util import (
 )
 
 
-def find_intra_water_bonds(atoms, o_type, h_type, box_len):
+def find_intra_water_bonds(
+    atoms: Atoms, o_type: int, h_type: int, box_len: Any
+) -> list[list[int, int]]:
+    """Gets the intramolecular OH bonds in water molecules
+
+    Args:
+        atoms (Atoms): ASE Atoms object
+        o_type (int): Integer type (LAMMPS type for example) of the O atom (atomic number in ASE)
+        h_type (int): Type of the H atom
+        box_len (Any): Box size dimensions
+
+    Returns:
+        list[list[int, int]]: Intramolecular OH bonds, wherein each bond is represented by tags
+    """
     bonds = []
     num_h_per_o = 2
 
@@ -38,14 +54,14 @@ def find_intra_water_bonds(atoms, o_type, h_type, box_len):
 
 
 def find_all_hydrogen_bonds(
-    solvation_shell,
-    donor_types,
-    acceptor_types,
-    h_types,
-    donor_H_distance=1.0,
-    donor_acceptor_cutoff=3.1,
-    ignore_hydrogens=False,
-):
+    solvation_shell: SolvationShell,
+    donor_types: list[int],
+    acceptor_types: list[int],
+    h_types: list[int],
+    donor_H_distance: float = 1.0,
+    donor_acceptor_cutoff: float = 3.1,
+    ignore_hydrogens: bool = False,
+) -> list[list[int, int]]:
     """
     Can find hydrogen bonds between donor and acceptor atom types. The H atom type must be provided as well.
     Hydrogen bonds are found according to a geometric criterion. A donor (D) is an
@@ -54,6 +70,18 @@ def find_all_hydrogen_bonds(
     follows: 1) the distance DA between the donor and acceptor should be less than
     or equal to 3.1 Angstroms, which corresponds to the first minimum in the O-O RDF
     of water, and 2) the angle HDA should be less than or equal to 30 degrees.
+
+    Args:
+        solvation_shell (SolvationShell): SolvationShell object
+        donor_types (list[int]): List of all the integral types of the donor atom(s)
+        acceptor_types (list[int]): List of all the integral types of the acceptor atom(s)
+        h_types (list[int]): List of all the integral types of the H atoms
+        donor_H_distance (float, optional): Intramolecular distance between the donor and H atom. Defaults to 1.0, which gets all the OH bonds in water.
+        donor_acceptor_cutoff (float, optional): Distance between the donor and acceptor, taking into account the minimum image convention. Defaults to 3.1. I have found that 3.5 is usually too big a cutoff for water, and 3.0 is too small a cutoff when I have chloride ions in the system.
+        ignore_hydrogens (bool, optional): If you set this to false, then the hydrogen bonds returned are between the H and the acceptor atom. Otherwise the bond is created between the acceptor and donor. Defaults to False.
+
+    Returns:
+        list[list[int, int]]: List of hydrogen bonds, wherein each bond is represented by tags
     """
     bonds = []  # will hold all found hydrogen bonds
 
@@ -112,18 +140,31 @@ def find_all_hydrogen_bonds(
 
 
 def find_hydrogen_bonds_to_donor_or_acceptor(
-    atom_tag,
-    solvation_shell,
-    donor_types,
-    acceptor_types,
-    h_types,
-    donor_H_distance=1.0,
-    donor_acceptor_cutoff=3.1,
-    ignore_hydrogens=False,
-):
+    atom_tag: int,
+    solvation_shell: SolvationShell,
+    donor_types: list[int],
+    acceptor_types: list[int],
+    h_types: list[int],
+    donor_H_distance: float = 1.0,
+    donor_acceptor_cutoff: float = 3.1,
+    ignore_hydrogens: bool = False,
+) -> list[list[int, int]]:
     """
     Find hydrogen bonds emanating from or to a particular donor/acceptor in a solvation shell. The donor type must have H atoms bonded to it, within a distance of donor_H_distance. The atom_tag is
     also present in the solvation shell.
+
+    Args:
+        atom_tag (int): tag of the atom from which or to which hydrogen bonds will be found. This can be either a donor or an acceptor
+        solvation_shell (SolvationShell): SolvationShell object
+        donor_types (list[int]): List of all the integral types of the donor atom(s)
+        acceptor_types (list[int]): List of all the integral types of the acceptor atom(s)
+        h_types (list[int]): List of all the integral types of the H atoms
+        donor_H_distance (float, optional): Intramolecular distance between the donor and H atom. Defaults to 1.0, which gets all the OH bonds in water.
+        donor_acceptor_cutoff (float, optional): Distance between the donor and acceptor, taking into account the minimum image convention. Defaults to 3.1. I have found that 3.5 is usually too big a cutoff for water, and 3.0 is too small a cutoff when I have chloride ions in the system.
+        ignore_hydrogens (bool, optional): If you set this to false, then the hydrogen bonds returned are between the H and the acceptor atom. Otherwise the bond is created between the acceptor and donor. Defaults to False.
+
+    Returns:
+        list[list[int, int]]: List of hydrogen bonds, wherein each bond is represented by tags
     """
     # Get the chemical symbols corresponding the acceptor types, donor types and H types
     donor_symbols = [chemical_symbols[x] for x in donor_types]
@@ -208,61 +249,5 @@ def find_hydrogen_bonds_to_donor_or_acceptor(
                     else [atom_tag, donor_tags[d_ind]]
                 )
                 bonds.append(bond)
-
-    return bonds
-
-
-def find_water_hydrogen_bonds(o_atom_tag, solvation_shell, o_type, h_type):
-    """
-    Find hydrogen bonds, in a solvation_shell with O and H types. The o_atom_tag is
-    also present in the solvation shell
-    """
-    bonds = []  # List of atom tags
-
-    all_tags = solvation_shell.atoms.get_tags()
-    all_pos = solvation_shell.atoms.get_positions()
-
-    o_query_index = solvation_shell.tag_manager.lookup_index_by_tag(o_atom_tag)
-    o_query_pos = all_pos[o_query_index]
-
-    # Find all O atom indices in ASE atoms object
-    o_all_ind = solvation_shell.atoms.symbols.search(chemical_symbols[o_type])
-    o_tags = all_tags[o_all_ind]
-    o_pos = all_pos[o_all_ind]
-
-    # Find all H atom indices in ASE atoms object
-    h_all_ind = solvation_shell.atoms.symbols.search(chemical_symbols[h_type])
-    h_tags = all_tags[h_all_ind]
-    h_pos = all_pos[h_all_ind]
-
-    # For a given O atom, find the neighbouring O atoms within 3.5 Angstrom
-    o_neigh = nearest_neighbours_within_cutoff(o_pos, o_query_pos, 3.0)
-
-    for o_ind in o_neigh:
-        # Find the distance
-        o_o_dist = minimum_image_distance(o_query_pos, o_pos[o_ind])
-
-        if math.isclose(o_o_dist, 0.0, rel_tol=1e-4):
-            continue
-
-        # Find the two closest H atom neighbours of this O atom
-        h_dist, h_ind = k_nearest_neighbours(h_pos, o_pos[o_ind], 2)
-
-        for current_h in h_ind:
-
-            # Neglect if the OA distance is greater than 2.42
-            o_a_dist = minimum_image_distance(h_pos[current_h], o_query_pos)
-            if o_a_dist > 2.42:
-                continue
-
-            # Get the angle
-            # HDA
-            angle = angle_between_points(h_pos[current_h], o_pos[o_ind], o_query_pos)
-
-            if angle > 90:
-                angle = 180 - angle
-
-            if angle <= 30:
-                bonds.append([o_atom_tag, h_tags[current_h]])
 
     return bonds

--- a/solvis/bond_helper.py
+++ b/solvis/bond_helper.py
@@ -117,24 +117,26 @@ def find_all_hydrogen_bonds(
             if donor_tag == acceptor_tags[a_ind]:
                 continue
 
-        # Find the closest H atoms to the donor atom within the D-H distance cutoff
-        h_ind = nearest_neighbours_within_cutoff(h_pos, d_query_pos, donor_H_distance)
-
-        for current_h in h_ind:
-            angle = angle_between_points(
-                h_pos[current_h], d_query_pos, acceptor_pos[a_ind]
+            # Find the closest H atoms to the donor atom within the D-H distance cutoff
+            h_ind = nearest_neighbours_within_cutoff(
+                h_pos, d_query_pos, donor_H_distance
             )
 
-            if angle > 90:
-                angle = 180 - angle
-
-            if angle <= 30:
-                bond = (
-                    [acceptor_tags[a_ind], h_tags[current_h]]
-                    if not ignore_hydrogens
-                    else [acceptor_tags[a_ind], donor_tag]
+            for current_h in h_ind:
+                angle = angle_between_points(
+                    h_pos[current_h], d_query_pos, acceptor_pos[a_ind]
                 )
-                bonds.append(bond)
+
+                if angle > 90:
+                    angle = 180 - angle
+
+                if angle <= 30:
+                    bond = (
+                        [acceptor_tags[a_ind], h_tags[current_h]]
+                        if not ignore_hydrogens
+                        else [acceptor_tags[a_ind], donor_tag]
+                    )
+                    bonds.append(bond)
 
     return bonds
 

--- a/solvis/geometric_utils.py
+++ b/solvis/geometric_utils.py
@@ -1,10 +1,11 @@
 import numpy as np
+import numpy.typing as npt
 import scipy
 from pyvista import PolyData
 
 
 class ConvexHull:
-    def __init__(self, points):
+    def __init__(self, points: npt.ArrayLike):
         """
         Create a convex hull. Note that the convex hull in SciPy (which is a wrapper around Qhull)
         does not have support for periodic boundary conditions. Make sure the coordinates are unwrapped.
@@ -23,9 +24,11 @@ class ConvexHull:
         self.area = hull.area
         self.volume = hull.volume
 
-    def pyvista_hull_from_convex_hull(self):
-        """
-        Return a PyVista PolyData object, converting from SciPy's convex hull
+    def pyvista_hull_from_convex_hull(self) -> PolyData:
+        """Get a PyVista PolyData object, converting from SciPy's convex hull
+
+        Returns:
+            PolyData: PyVista PolyData object
         """
         faces_pyvistaformat = np.column_stack(
             (3 * np.ones((len(self.faces), 1), dtype=int), self.faces)
@@ -33,9 +36,11 @@ class ConvexHull:
         polyhull = PolyData(self.points, faces_pyvistaformat)
         return polyhull
 
-    def get_edges(self):
-        """
-        Get a numPy array of edges from the faces, of shape (n_edges,2).
+    def get_edges(self) -> npt.ArrayLike:
+        """Convenience function for getting a numPy array of edges from the faces, of shape (n_edges,2).
+
+        Returns:
+            npt.ArrayLike: NumPy array of edges
         """
         edges = set()
 

--- a/solvis/render_helper.py
+++ b/solvis/render_helper.py
@@ -1,98 +1,255 @@
+from typing import Any, Optional
 from .util import merge_options_keeping_override, merge_options
+
+
+class RenderingUnitTypeInfo:
+    def __init__(self, color: Optional[str] = None, **render_options):
+        """Contains rendering information about an atom type or bond type
+
+        Args:
+            color (str, optional): Color corresponding to an integral atom type or bond type, which will be applied to all atoms of this atom type. Defaults to None.
+            render_options: Additional PyVista rendering options for the atom
+        """
+        if color is None:
+            color = "black"  # Default atom or bond color
+        self.color = color
+        if self.color in render_options:
+            del render_options["color"]
+        self.render_options = render_options
+
+
+class SingleAtomInfo:
+    def __init__(
+        self,
+        name: str,
+        tag: int,
+        atom_type: int,
+        color: str,
+        label: Optional[str] = None,
+        **render_options
+    ):
+        """
+        Rendering information for a single atom.
+
+        Args:
+            name (str): PyVista actor name for the atom
+            tag (int): Atom tag
+            type (int): Atom type
+            color (str): Color of the atom. Must correspond to a color recognized by PyVista
+            label (Optional[str], optional): Text label for the atom. Defaults to None, meaning the atom will have no label.
+        """
+        self.name = name
+        self.tag = tag
+        self.type = atom_type
+        self.color = color
+        self.label = label
+        self.render_options = render_options
+
+
+class AllAtomInfo:
+    def __init__(self):
+        """
+        Rendering information for all atoms. Contains a list of SingleAtomInfo objects (and some other things)
+        """
+        self.atoms = []
+        # These numbers do not reflect the actual numbers of such items
+        # since they can be deleted. They are just there to bookkeep and make sure
+        # you always have a unique actor_name
+        self.num_atoms = 0
+        self.default_atom_color = "black"
+
+    def _first(self, iterable) -> Optional[SingleAtomInfo]:
+        """Returns the first match, if any
+
+        Returns:
+            Optional[SingleAtomInfo]: Returns None if not found
+        """
+        for item in iterable:
+            return item
+        return None
+
+    def find_atom_with_name(self, actor_name: str) -> Optional[SingleAtomInfo]:
+        """Get the first SingleAtomInfo object such that the actor name matches the target actor_name
+
+        Args:
+            actor_name (str): Target actor name to match against
+
+        Returns:
+            Optional[SingleAtomInfo]: Either the SingleAtomInfo object or None
+        """
+        return self._first(x for x in self.atoms if x.name == actor_name)
+
+    def find_atom_with_tag(self, tag: int) -> Optional[SingleAtomInfo]:
+        """Get the first SingleAtomInfo object such that the atom tag matches the target tag
+
+        Args:
+            tag (str): Target atom tag to match against
+
+        Returns:
+            Optional[SingleAtomInfo]: Either the SingleAtomInfo object or None
+        """
+        return self._first(x for x in self.atoms if x.tag == tag)
+
+    def find_first_atom_index_with_name(self, actor_name: str) -> Optional[str]:
+        """Find the index of the atom info corresponding to a given actor name
+
+        Args:
+            actor_name (str): The PyVista actor name
+
+        Returns:
+            Optional[str]: Returns None if not found, or else returns the index in atoms
+        """
+        return self._first(i for i, x in enumerate(self.atoms) if x.name == actor_name)
+
+    def add_atom(
+        self,
+        tag: int,
+        atom_type: int,
+        color: str,
+        actor_name: Optional[str] = None,
+        label: Optional[str] = None,
+        **render_options
+    ) -> None:
+        """Add a new atom
+
+        Args:
+            name (str): If you don't provide actor_name, a name is assigned using the number of atoms. Defaults to None; i.e. a name is automatically assigned.
+            tag (int): Atom tag
+            type (int): Atom type
+            color (str): Color of the atom. Must be accepted by PyVista
+            label (Optional[str], optional): Text label for the atom. Defaults to None; i.e. no label.
+            render_options: PyVista rendering options
+        """
+        self.num_atoms += 1
+        # Get the name of the actor
+        if actor_name is not None:
+            name = actor_name
+        else:
+            name = "atom_" + str(self.num_atoms)
+        # If the actor name already exists, ovewrite it, while printing a warning
+        existing_index = self.find_first_atom_index_with_name(name)
+        new_atom_info = SingleAtomInfo(
+            name=name,
+            tag=tag,
+            atom_type=atom_type,
+            color=color,
+            label=label,
+            **render_options
+        )
+        if existing_index is not None:
+            # overwrite it
+            print(
+                "Warning: Overwriting atom information values for an actor with name ",
+                name,
+            )
+            self.atoms[existing_index] = new_atom_info
+        else:
+            # Add a new atom
+            self.atoms.append(new_atom_info)
 
 
 class RendererRepresentation:
     def __init__(self):
-        self.atoms = {}
+        self.atoms = AllAtomInfo()
         self.bonds = {}
         self.hydrogen_bonds = {}
         self.hulls = {}
         self.atom_type_rendering = {}
         self.bond_type_rendering = {}
-        # These numbers do not reflect the actual numbers of such items
-        # since they can be deleted. They are just there to bookkeep and make sure
-        # you always have a unique actor_name
-        self.num_atoms = 0
+
         self.num_bonds = 0
         self.num_hbonds = 0
         self.num_hulls = 0
         self.default_bond_color = "black"
-        self.default_atom_color = "black"
+
         # Hydrogen bond rendering
         self.hbond_rendering = dict(segment_spacing=0.175, color="grey", width=10.0)
 
-    def add_atom_type_rendering(self, atom_type, color=None, **render_options):
-        """
-        Render options that you can put into add_single_atom_as_sphere in the plotter object
-        """
-        if color is None:
-            color = self.default_atom_color
-        # color should not be in render_options
-        if color in render_options:
-            del render_options["color"]
-        atom_info = dict(color=color, render_options=render_options)
-        self.atom_type_rendering[atom_type] = atom_info
+    def add_atom_type_rendering(
+        self, atom_type: int, color: Optional[str] = None, **render_options
+    ):
+        """Render options that you can put into add_single_atom_as_sphere in the plotter object
 
-    def add_bond_type_rendering(self, bond_type, color=None, **render_options):
+        Args:
+            atom_type (int): Integral atom type
+            color (str, optional): Color corresponding to the atom type. Must be a color recognized by PyVista. Defaults to a color black if None.
+            render_options: Additional PyVista rendering options for the atom, rendered as a sphere
         """
-        Assign a particular color to all bonds of a particular bond type
+        self.atom_type_rendering[atom_type] = RenderingUnitTypeInfo(
+            color=color, **render_options
+        )
+
+    def add_bond_type_rendering(
+        self, bond_type: int, color: Optional[str] = None, **render_options
+    ):
+        """Assign a particular color to all bonds of a particular bond type
+
+        Args:
+            bond_type (int): Integral bond type
+            color (Optional[str], optional): Color corresponding to the bond type. Must be a color recognized by PyVista. Defaults to a color black if None.
+            render_options: Additional PyVista rendering options for the bond, rendered as a cylinder
         """
-        if color is None:
-            color = self.default_bond_color
-        # color should not be in render_options
-        if color in render_options:
-            del render_options["color"]
-        bond_info = dict(color=color, render_options=render_options)
-        self.bond_type_rendering[bond_type] = bond_info
+        self.bond_type_rendering[bond_type] = RenderingUnitTypeInfo(
+            color=color, **render_options
+        )
 
     def set_hbond_rendering(self, **render_options):
         """
         Set the segment_spacing, color or width of hydrogen bonds
         Rendered as a dashed line
+
+        Args:
+            render_options: Rendering options for the hydrogen bond, rendered as a dashed line
         """
         options = merge_options(self.hbond_rendering, render_options)
         self.hbond_rendering = options
 
+    """
+        render_options overrides the render options provided by atom type.
+        If you don't provide actor_name, a name is assigned using the number of atoms
+        """
+
     def add_atom(
         self,
-        atom_tag,
-        atom_type,
-        color=None,
-        actor_name=None,
-        label=None,
+        atom_tag: int,
+        atom_type: int,
+        color: Optional[str] = None,
+        actor_name: Optional[str] = None,
+        label: Optional[str] = None,
         **render_options
     ):
         """
-        render_options overrides the render options provided by atom type.
-        If you don't provide actor_name, a name is assigned using the number of atoms
+        Adds an atom to the RendererRepresentation object. All options you enter will override properties set by the atom type.
+
+        Args:
+            atom_tag (int): The tag of the atom
+            atom_type (int): The atom type
+            color (Optional[str], optional): Color of the atom. This overrides the color set by the atom type. Defaults to None, which means the color set by the atom type is used, if the atom type information has previously been set.
+            actor_name (Optional[str], optional): The name of the PyVista actor. If you don't provide actor_name, a name is assigned using the number of atoms. Defaults to None; i.e. a name is automatically assigned.
+            label (Optional[str], optional): A text label of the atom. Defaults to None.
+            render_options: Additional PyVista options that overrides the render options provided by the atom type
         """
         # Get the render options for the atom type, if they exist
         if atom_type in self.atom_type_rendering:
             options = merge_options_keeping_override(
-                self.atom_type_rendering[atom_type]["render_options"], render_options
+                self.atom_type_rendering[atom_type].render_options, render_options
             )
             if color is None:
-                color = self.atom_type_rendering[atom_type]["color"]
+                color = self.atom_type_rendering[atom_type].color
         else:
             print("Warning: No atom type render options set for atom type", atom_type)
             options = render_options
             if color is None:
                 print("Warning: Setting atom color to default.")
                 color = self.default_atom_color
-        self.num_atoms += 1
-        if actor_name is not None:
-            name = actor_name
-        else:
-            name = "atom_" + str(self.num_atoms)
-        atom_info = {
-            "tag": atom_tag,
-            "type": atom_type,
-            "color": color,
-            "label": label,
-            "render_options": options,
-        }
-        self.atoms[name] = atom_info
-        # Add to the number of atoms
+        self.atoms.add_atom(
+            tag=atom_tag,
+            atom_type=atom_type,
+            color=color,
+            actor_name=actor_name,
+            label=label,
+            **options
+        )
 
     def add_hull(self, actor_name=None, **render_options):
         """
@@ -123,90 +280,112 @@ class RendererRepresentation:
         self.hydrogen_bonds[name] = hydrogen_bond_info
 
     def get_render_info_from_atom_name(self, actor_name):
-        return self.atoms.get(actor_name).get("render_options")
+        atom_info = self.atoms.find_atom_with_name(actor_name=actor_name)
+        if atom_info is None:
+            return None
+        else:
+            return atom_info.render_options
 
     def get_color_from_atom_name(self, actor_name):
-        return self.atoms.get(actor_name).get("color")
+        atom_info = self.atoms.find_atom_with_name(actor_name=actor_name)
+        if atom_info is None:
+            return None
+        else:
+            return atom_info.color
 
     def get_tag_from_atom_name(self, actor_name):
         """
-        Get the atom tag, given the atom actor name in the self.atoms dictionary
+        Get the atom tag, given the atom actor name in self.atoms
         """
-        return self.atoms.get(actor_name).get("tag")
+        atom_info = self.atoms.find_atom_with_name(actor_name=actor_name)
+        if atom_info is None:
+            return None
+        else:
+            return atom_info.tag
 
-    def get_atom_name_from_tag(self, target_atom_tag):
-        """
-        Function to find the 'color' based on the value of 'tag' in a nested dictionary.
+    def get_atom_name_from_tag(self, target_atom_tag: int) -> Optional[str]:
+        """Get the actor name, given the tag of the atom
 
-        Parameters:
-        - target_atom_tag: The value of 'tag' to search for.
+        Args:
+            target_atom_tag (int): Atom tag
 
         Returns:
-        - The value associated with the 'color' option if found, otherwise None.
+            Optional[str]: The actor name, or None if it does not exist
         """
-        for key, value in self.atoms.items():
-            if isinstance(value, dict):
-                if "tag" in value and value["tag"] == target_atom_tag:
-                    return key
-        return None
+        atom_info = self.atoms.find_atom_with_tag(target_atom_tag)
+        if atom_info is not None:
+            return atom_info.name
+        else:
+            return None
 
     def get_atom_rendering_options(self, atom_type):
-        return self.atom_type_rendering.get(atom_type).get("render_options")
+        return self.atom_type_rendering.get(atom_type).render_options
 
-    def update_atom_render_opt(self, actor_name, **render_options):
-        """
-        Function to replace the value of a key in a flat dictionary.
+    def update_atom_render_opt(self, actor_name: str, **render_options) -> bool:
+        """Update the rendering options of an atom, given the actor name
 
-        Parameters:
-        - actor_name: The key in the atoms dict whose value needs to be replaced.
-        - render_options: The new render options.
+        Args:
+            actor_name (str): PyVista actor name of the atom
+            render_options: The new render options.
 
         Returns:
-        - True if the replacement was successful, False if actor_name was not found.
+            bool: True if the replacement was successful, False if actor_name was not found.
         """
-        if actor_name in self.atoms:
+        atom_index = self.atoms.find_first_atom_index_with_name(actor_name=actor_name)
+        if atom_index is None:
+            return False  # the atom corresponding to the name was not found
+        else:
             # Merge with previous options, overwriting
             options = merge_options_keeping_override(
-                self.atoms.get(actor_name).get("render_options"), render_options
+                self.atoms.atoms[atom_index].render_options, render_options
             )
-            self.atoms[actor_name]["render_options"] = options
+            self.atoms.atoms[atom_index].render_options = options
             return True
-        else:
-            return False
 
-    def update_atom_color(self, actor_name, color):
-        """
+    """
         Function to change the color of an atom, given the actor_name
 
         Parameters:
-        - actor_name: The key in the atoms dict whose value needs to be replaced.
-        - render_options: The new render options.
+        actor_name: The key in the atoms dict whose value needs to be replaced.
+        render_options: The new render options.
 
         Returns:
         - True if the replacement was successful, False if actor_name was not found.
         """
-        if actor_name in self.atoms:
-            self.atoms[actor_name]["color"] = color
-            return True
-        else:
-            return False
 
-    def set_atom_label(self, actor_name, label):
-        """
-        Function to change or set the label of an atom, given the actor_name
+    def update_atom_color(self, actor_name: str, color: str) -> bool:
+        """Function to change the color of an atom, given the actor_name
 
-        Parameters:
-        - actor_name: The key in the atoms dict whose value needs to be replaced.
-        - label: The text of the label.
+        Args:
+            actor_name (str): The PyVista actor name
+            color (str): The new color
 
         Returns:
-        - True if the replacement was successful, False if actor_name was not found.
+            bool: True if the replacement was successful, False if the actor_name was not found
         """
-        if actor_name in self.atoms:
-            self.atoms[actor_name]["label"] = label
-            return True
+        atom_index = self.atoms.find_first_atom_index_with_name(actor_name=actor_name)
+        if atom_index is None:
+            return False  # the atom corresponding to the name was not found
         else:
-            return False
+            self.atoms.atoms[atom_index].color = color
+            return True
+
+    def set_atom_label(self, actor_name: str, label: str) -> bool:
+        """Function to change or set the label of an atom, given the actor_name
+
+        Args:
+            actor_name (str): The (unique) PyVista actor name
+            label (str): The text of the label.
+
+        Returns:
+            bool: True if the replacement was successful, False if actor_name was not found.
+        """
+        atom_index = self.atoms.find_first_atom_index_with_name(actor_name=actor_name)
+        if atom_index is None:
+            return False  # the atom corresponding to the name was not found
+        else:
+            self.atoms.atoms[atom_index].label = label
+            return True
 
     def update_bond_render_opt(self, actor_name, **render_options):
         """
@@ -250,8 +429,7 @@ class RendererRepresentation:
         else:
             return False
 
-    def find_color_by_atom_tag(self, target_atom_tag):
-        """
+    """
         Function to find the 'color' based on the value of 'tag' in a nested dictionary.
 
         Parameters:
@@ -260,12 +438,13 @@ class RendererRepresentation:
         Returns:
         - The value associated with the 'color' option if found, otherwise None.
         """
-        for key, value in self.atoms.items():
-            if isinstance(value, dict):
-                if "tag" in value and value["tag"] == target_atom_tag:
-                    if "color" in value:
-                        return value["color"]
-        return None
+
+    def find_color_by_atom_tag(self, target_atom_tag: int) -> Optional[str]:
+        atom_info = self.atoms.find_atom_with_tag(target_atom_tag)
+        if atom_info is not None:
+            return atom_info.color
+        else:
+            return None
 
     def add_bond(
         self,
@@ -287,7 +466,7 @@ class RendererRepresentation:
             b_color = self.find_color_by_atom_tag(bond_tags[-1])
         elif colorby == "bondtype":
             if bond_type in self.bond_type_rendering.keys():
-                a_color = self.bond_type_rendering[bond_type].get("color")
+                a_color = self.bond_type_rendering[bond_type].color
                 b_color = a_color
             else:
                 print(
@@ -302,7 +481,7 @@ class RendererRepresentation:
         # Get the render options for the atom type, if they exist
         if bond_type in self.bond_type_rendering:
             options = merge_options_keeping_override(
-                self.bond_type_rendering[bond_type].get("render_options"),
+                self.bond_type_rendering[bond_type].render_options,
                 render_options,
             )
         else:
@@ -344,10 +523,15 @@ class RendererRepresentation:
         """
         Delete an actor from atoms, bonds or hulls
         """
-        if actor_name in self.atoms:
-            del self.atoms[actor_name]
+        # Search for the atom in self.atoms
+        atom_index = self.atoms.find_first_atom_index_with_name(actor_name=actor_name)
+        # the name was found in self.atoms
+        if atom_index is not None:
+            self.atoms.atoms.pop(atom_index)
             return True
-        elif actor_name in self.bonds:
+
+        # Check for bonds, hulls and hydrogen bonds
+        if actor_name in self.bonds:
             del self.bonds[actor_name]
             return True
         elif actor_name in self.hulls:
@@ -359,21 +543,33 @@ class RendererRepresentation:
         else:
             return False
 
-    def delete_atom(self, actor_name):
+    def delete_atom(self, actor_name: str) -> bool:
+        """Delete an atom, given the actor name
+
+        Args:
+            actor_name (str): PyVista actor name of the atom
+
+        Returns:
+            bool: True if atom was found and deleted, otherwise False if not found
         """
-        Delete an atom from the self.atoms dict, given the actor name (key).
-        If not found, returns False
-        """
-        if actor_name in self.atoms:
-            del self.atoms[actor_name]
+        # Search for the atom in self.atoms
+        atom_index = self.atoms.find_first_atom_index_with_name(actor_name=actor_name)
+        # the name was found in self.atoms
+        if atom_index is not None:
+            self.atoms.atoms.pop(atom_index)
             return True
         else:
             return False
 
-    def delete_bond(self, actor_name):
-        """
-        Delete a bond from the self.bonds dict, given the actor name (key).
+    def delete_bond(self, actor_name: str) -> bool:
+        """Delete a bond from the self.bonds dict, given the actor name (key).
         If not found, returns False
+
+        Args:
+            actor_name (str): PyVista actor name
+
+        Returns:
+            bool: True if successfully deleted, otherwise Falses
         """
         if actor_name in self.bonds:
             del self.bonds[actor_name]
@@ -381,10 +577,15 @@ class RendererRepresentation:
         else:
             return False
 
-    def delete_hull(self, actor_name):
-        """
-        Delete a hull from the self.bonds dict, given the actor name (key).
+    def delete_hull(self, actor_name: str) -> bool:
+        """Delete a hull from the self.hulls dict, given the actor name (key).
         If not found, returns False
+
+        Args:
+            actor_name (str): PyVista actor name
+
+        Returns:
+            bool: True if successfully deleted, otherwise Falses
         """
         if actor_name in self.hulls:
             del self.hulls[actor_name]

--- a/solvis/render_helper.py
+++ b/solvis/render_helper.py
@@ -80,6 +80,17 @@ class AllAtomInfo:
         """
         return self._first(x for x in self.atoms if x.name == actor_name)
 
+    def find_first_atom_with_type(self, atom_type: int) -> Optional[SingleAtomInfo]:
+        """Get the first SingleAtomInfo object such that the atom type matches the target type
+
+        Args:
+            type (int): Target atom tag to match against
+
+        Returns:
+            Optional[SingleAtomInfo]: Optional[SingleAtomInfo]: Either the SingleAtomInfo object or None
+        """
+        return self._first(x for x in self.atoms if x.type == atom_type)
+
     def find_atom_with_tag(self, tag: int) -> Optional[SingleAtomInfo]:
         """Get the first SingleAtomInfo object such that the atom tag matches the target tag
 
@@ -351,6 +362,21 @@ class RendererRepresentation:
             Optional[str]: The actor name, or None if it does not exist
         """
         atom_info = self.atoms.find_atom_with_tag(target_atom_tag)
+        if atom_info is not None:
+            return atom_info.name
+        else:
+            return None
+
+    def get_center_actor_name_from_type(self, center_atom_type: int) -> Optional[str]:
+        """Get the actor name of the center, given the type of the center
+
+        Args:
+            center_atom_type (int): Atom type of the center
+
+        Returns:
+            Optional[str]: The actor name, or None if it does not exist
+        """
+        atom_info = self.atoms.find_first_atom_with_type(center_atom_type)
         if atom_info is not None:
             return atom_info.name
         else:

--- a/solvis/render_helper.py
+++ b/solvis/render_helper.py
@@ -149,6 +149,10 @@ class AllAtomInfo:
 
 
 class RendererRepresentation:
+    """Class for handling all the rendering information for each atom (rendered as a sphere),
+    bond (rendered as a cylinder), hull (convex shape) and hydrogen bond (dotted line).
+    """
+
     def __init__(self):
         self.atoms = AllAtomInfo()
         self.bonds = {}
@@ -251,9 +255,12 @@ class RendererRepresentation:
             **options
         )
 
-    def add_hull(self, actor_name=None, **render_options):
-        """
-        for options to: add_hull(self,hull:PolyData, **color_or_additional_mesh_options)
+    def add_hull(self, actor_name: Optional[str] = None, **render_options) -> None:
+        """for options to: add_hull(self,hull:PolyData, **color_or_additional_mesh_options)
+
+        Args:
+            actor_name (Optional[str], optional): The name of the PyVista actor. If you don't provide one, a name is
+            generated using the number of hulls added. Defaults to None.
         """
         self.num_hulls += 1
         if actor_name is not None:
@@ -262,11 +269,21 @@ class RendererRepresentation:
             name = "hull_" + str(self.num_hulls)
         self.hulls[name] = render_options
 
-    def add_hydrogen_bond(self, bond_tags, actor_name=None, **render_options):
+    """
+        
         """
-        render_options can override any of the following (default options are:)
+
+    def add_hydrogen_bond(
+        self, bond_tags: list[int], actor_name: Optional[str] = None, **render_options
+    ) -> None:
+        """Adds a hydrogen bond. The kwargs render_options can override any of the following (default options are:)
         segment_spacing=0.175, color="grey", width=10.0
         Hydrogen bonds will be rendered as dashed lines
+
+        Args:
+            bond_tags (list[int]): Tags corresponding to the two atoms in the bond.
+            actor_name (Optional[str], optional): The name of the PyVista actor. If you don't provide one, a name is
+            generated using the number of hydrogen bonds added. Defaults to None.
         """
         options = merge_options(self.hbond_rendering, render_options)
 
@@ -279,23 +296,44 @@ class RendererRepresentation:
         hydrogen_bond_info = {"tags": bond_tags, "render_options": options}
         self.hydrogen_bonds[name] = hydrogen_bond_info
 
-    def get_render_info_from_atom_name(self, actor_name):
+    def get_render_info_from_atom_name(self, actor_name: str) -> Optional[dict]:
+        """Obtain the rendering information, given the actor name of an atom
+
+        Args:
+            actor_name (str): Actor name
+
+        Returns:
+            Optional[dict[str]]: Dictionary containing rendering options, or None if the actor_name cannot be found.
+        """
         atom_info = self.atoms.find_atom_with_name(actor_name=actor_name)
         if atom_info is None:
             return None
         else:
             return atom_info.render_options
 
-    def get_color_from_atom_name(self, actor_name):
+    def get_color_from_atom_name(self, actor_name: str) -> Optional[str]:
+        """Obtain the color of a particular atom, given its actor name
+
+        Args:
+            actor_name (str): Actor name of the atom
+
+        Returns:
+            Optional[str]: Color of the atom, or None if actor_name cannot be found.
+        """
         atom_info = self.atoms.find_atom_with_name(actor_name=actor_name)
         if atom_info is None:
             return None
         else:
             return atom_info.color
 
-    def get_tag_from_atom_name(self, actor_name):
-        """
-        Get the atom tag, given the atom actor name in self.atoms
+    def get_tag_from_atom_name(self, actor_name: str) -> Optional[int]:
+        """Get the atom tag of an atom, given its actor name
+
+        Args:
+            actor_name (str): Actor name of the atom
+
+        Returns:
+            Optional[int]: Atom tag or None of actor_name cannot be found
         """
         atom_info = self.atoms.find_atom_with_name(actor_name=actor_name)
         if atom_info is None:
@@ -318,7 +356,15 @@ class RendererRepresentation:
         else:
             return None
 
-    def get_atom_rendering_options(self, atom_type):
+    def get_atom_rendering_options(self, atom_type: int) -> Optional[dict]:
+        """Get the rendering options given the atom type
+
+        Args:
+            atom_type (int): Atom type of a particular atom
+
+        Returns:
+            Optional[dict]:  Dictionary containing rendering options, or None if the actor_name cannot be found.
+        """
         return self.atom_type_rendering.get(atom_type).render_options
 
     def update_atom_render_opt(self, actor_name: str, **render_options) -> bool:
@@ -429,17 +475,15 @@ class RendererRepresentation:
         else:
             return False
 
-    """
-        Function to find the 'color' based on the value of 'tag' in a nested dictionary.
+    def find_color_by_atom_tag(self, target_atom_tag: int) -> Optional[str]:
+        """Function to find the 'color' of an atom, based on the value of the 'tag' of the atom
 
-        Parameters:
-        - target_atom_tag: The value of 'tag' to search for.
+        Args:
+            target_atom_tag (int): The atom tag of the atom
 
         Returns:
-        - The value associated with the 'color' option if found, otherwise None.
+            Optional[str]: The value associated with color of the atom, otherwise None.
         """
-
-    def find_color_by_atom_tag(self, target_atom_tag: int) -> Optional[str]:
         atom_info = self.atoms.find_atom_with_tag(target_atom_tag)
         if atom_info is not None:
             return atom_info.color
@@ -448,16 +492,22 @@ class RendererRepresentation:
 
     def add_bond(
         self,
-        bond_tags,
-        bond_type,
-        colorby="atomcolor",
-        actor_name=None,
+        bond_tags: list[int],
+        bond_type: int,
+        colorby: str = "atomcolor",
+        actor_name: Optional[str] = None,
         **render_options
     ):
-        """
-        render_options can override any of the following (default options are:)
+        """Add a bond to the RendererRepresentation object. The kwargs render_options can override any of the following (default options are:)
         radius=0.1, resolution=1, bond_gradient_start=0.0, asymmetric_gradient_start=None,**mesh_options_override_default
         colorby: "atomcolor" or "bondtype". If not any of these options, set to the default color.
+
+        Args:
+            bond_tags (list[int]): Tags of the two atoms in the bond
+            bond_type (int): Integral bond type of the bond
+            colorby (str, optional): Decides how the bond will be coloured. Defaults to "atomcolor".
+            actor_name (Optional[str], optional): Name of the bond actor. If not provided, then a unique actor name
+            is created based on the number of bonds already added. Defaults to None.
         """
         # We need a_color and b_color to render the bond
         if colorby == "atomcolor":
@@ -501,16 +551,17 @@ class RendererRepresentation:
         }
         self.bonds[name] = bond_info
 
-    def update_bond_colors(self, actor_name, a_color, b_color):
-        """
-        Function to change the bond colors of a given bond actor
+    def update_bond_colors(self, actor_name: str, a_color: str, b_color: str) -> bool:
+        """Function to change the bond colors of a given bond actor
 
-        Parameters:
-        - actor_name: The key in the atoms dict whose value needs to be replaced.
-        - render_options: The new render options.
+        Args:
+            actor_name (str): The actor name of the bond, whose colours need to be changed.
+            a_color (str): End point ("A") color of the bond.
+            b_color (str): End point ("B) color of the bond. a_color and b_color can be the same.
+            render_options: The new render options
 
         Returns:
-        - True if the replacement was successful, False if actor_name was not found.
+            bool: True if successfully changed.
         """
         if actor_name in self.bonds:
             self.bonds[actor_name]["a_color"] = a_color
@@ -519,9 +570,14 @@ class RendererRepresentation:
         else:
             return False
 
-    def delete_actor(self, actor_name):
-        """
-        Delete an actor from atoms, bonds or hulls
+    def delete_actor(self, actor_name: str) -> bool:
+        """Delete an actor from atoms, bonds or hulls
+
+        Args:
+            actor_name (str): Name of the actor
+
+        Returns:
+            bool: True if successfully deleted, otherwise False
         """
         # Search for the atom in self.atoms
         atom_index = self.atoms.find_first_atom_index_with_name(actor_name=actor_name)

--- a/solvis/render_helper.py
+++ b/solvis/render_helper.py
@@ -1,5 +1,6 @@
 from typing import Any, Optional
 from .util import merge_options_keeping_override, merge_options
+import warnings
 
 
 class RenderingUnitTypeInfo:
@@ -26,7 +27,7 @@ class SingleAtomInfo:
         atom_type: int,
         color: str,
         label: Optional[str] = None,
-        **render_options
+        **render_options,
     ):
         """
         Rendering information for a single atom.
@@ -108,7 +109,7 @@ class AllAtomInfo:
         color: str,
         actor_name: Optional[str] = None,
         label: Optional[str] = None,
-        **render_options
+        **render_options,
     ) -> None:
         """Add a new atom
 
@@ -134,13 +135,12 @@ class AllAtomInfo:
             atom_type=atom_type,
             color=color,
             label=label,
-            **render_options
+            **render_options,
         )
         if existing_index is not None:
             # overwrite it
-            print(
-                "Warning: Overwriting atom information values for an actor with name ",
-                name,
+            warnings.warn(
+                f"Overwriting atom information values for an actor with name {name}"
             )
             self.atoms[existing_index] = new_atom_info
         else:
@@ -220,7 +220,7 @@ class RendererRepresentation:
         color: Optional[str] = None,
         actor_name: Optional[str] = None,
         label: Optional[str] = None,
-        **render_options
+        **render_options,
     ):
         """
         Adds an atom to the RendererRepresentation object. All options you enter will override properties set by the atom type.
@@ -241,10 +241,10 @@ class RendererRepresentation:
             if color is None:
                 color = self.atom_type_rendering[atom_type].color
         else:
-            print("Warning: No atom type render options set for atom type", atom_type)
+            warnings.warn(f"No atom type render options set for atom type {atom_type}")
             options = render_options
             if color is None:
-                print("Warning: Setting atom color to default.")
+                warnings.warn("Setting atom color to default.")
                 color = self.default_atom_color
         self.atoms.add_atom(
             tag=atom_tag,
@@ -252,7 +252,7 @@ class RendererRepresentation:
             color=color,
             actor_name=actor_name,
             label=label,
-            **options
+            **options,
         )
 
     def add_hull(self, actor_name: Optional[str] = None, **render_options) -> None:
@@ -496,7 +496,7 @@ class RendererRepresentation:
         bond_type: int,
         colorby: str = "atomcolor",
         actor_name: Optional[str] = None,
-        **render_options
+        **render_options,
     ):
         """Add a bond to the RendererRepresentation object. The kwargs render_options can override any of the following (default options are:)
         radius=0.1, resolution=1, bond_gradient_start=0.0, asymmetric_gradient_start=None,**mesh_options_override_default
@@ -519,8 +519,8 @@ class RendererRepresentation:
                 a_color = self.bond_type_rendering[bond_type].color
                 b_color = a_color
             else:
-                print(
-                    "Warning: Setting bonds to default since colorby was bondtype, but bond_type color was not set\n"
+                warnings.warn(
+                    "Setting bonds to default since colorby was bondtype, but bond_type color was not set"
                 )
                 a_color = self.default_bond_color
                 b_color = a_color
@@ -535,7 +535,7 @@ class RendererRepresentation:
                 render_options,
             )
         else:
-            print("Warning: No bond type render options set for bond type", bond_type)
+            warnings.warn(f"No bond type render options set for bond type {bond_type}")
             options = render_options
         self.num_bonds += 1
         if actor_name is not None:

--- a/solvis/vis_initializers.py
+++ b/solvis/vis_initializers.py
@@ -1,3 +1,4 @@
+from solvis.util import merge_options_keeping_override
 from .solvation_shell import SolvationShell
 from .render_helper import RendererRepresentation
 from .visualization import AtomicPlotter
@@ -29,7 +30,7 @@ def fill_render_rep_bonds_from_solv_shell_center(
     The bond type must have ALREADY been set.
     colorby: "atomcolor" or "bondtype"
     """
-    bond_render_opt = render_rep.bond_type_rendering[bond_type].get("render_options")
+    bond_render_opt = render_rep.bond_type_rendering[bond_type].render_options
 
     for solv_atom in solv_shell.atoms:
         iatom_tag = solv_atom.tag
@@ -45,7 +46,7 @@ def fill_render_rep_bonds_from_edges(render_rep, edges, bond_type, colorby):
     The bond type must have ALREADY been set.
     colorby: "atomcolor" or "bondtype"
     """
-    bond_render_opt = render_rep.bond_type_rendering[bond_type].get("render_options")
+    bond_render_opt = render_rep.bond_type_rendering[bond_type].render_options
 
     for bond in edges:
         render_rep.add_bond(bond, bond_type, colorby=colorby, **bond_render_opt)
@@ -59,9 +60,10 @@ def fill_render_rep_hbonds_from_edges(render_rep, edges, **render_options):
     segment_spacing=0.175, color="grey", width=10.0
     """
     hbond_render_opt = render_rep.hbond_rendering
+    options = merge_options_keeping_override(hbond_render_opt, render_options)
 
     for bond in edges:
-        render_rep.add_hydrogen_bond(bond, actor_name=None, **render_options)
+        render_rep.add_hydrogen_bond(bond, actor_name=None, **options)
 
 
 def coord_from_tag(atom_tag, solv_shell):
@@ -89,19 +91,17 @@ def populate_plotter_from_solv_shell(
 
     # Add the atoms
     # Loop through all atoms
-    for actor_name in render_rep.atoms.keys():
-        atom_tag = render_rep.atoms[actor_name]["tag"]
-        atom_coord = coord_from_tag(atom_tag, solv_shell)
-        render_opt = render_rep.atoms[actor_name]["render_options"]
-        atom_color = render_rep.atoms[actor_name]["color"]
+    for atom in render_rep.atoms.atoms:
+        atom_coord = coord_from_tag(atom.tag, solv_shell)
+        render_opt = atom.render_options
         # Add the atom to the plotter
         plotter.add_single_atom_as_sphere(
-            point=atom_coord, color=atom_color, actor_name=actor_name, **render_opt
+            point=atom_coord, color=atom.color, actor_name=atom.name, **render_opt
         )
         # Add the label
-        if render_rep.atoms[actor_name]["label"] is not None:
+        if atom.label is not None:
             label_points.append(atom_coord)
-            label_text.append(render_rep.atoms[actor_name]["label"])
+            label_text.append(atom.label)
 
     # Add the bonds
     # Loop through all bonds

--- a/tests/test_renderer_representation.py
+++ b/tests/test_renderer_representation.py
@@ -73,12 +73,12 @@ def test_renderer_helper_ctp_system(capped_trigonal_prism_solv_system):
     render_rep.add_atom_type_rendering(
         atom_type=fe_type, color=fe_color, radius=fe_radius
     )
-    assert render_rep.atom_type_rendering[fe_type].get("color") == "black"
+    assert render_rep.atom_type_rendering[fe_type].color == "black"
     fe_atom_options = render_rep.get_atom_rendering_options(atom_type=fe_type)
     assert fe_atom_options == {"radius": 0.3}
     # Atom type of the O atoms
     render_rep.add_atom_type_rendering(atom_type=o_type, color=o_color, radius=o_radius)
-    assert render_rep.atom_type_rendering[o_type].get("color") == "midnightblue"
+    assert render_rep.atom_type_rendering[o_type].color == "midnightblue"
     o_atom_options = render_rep.get_atom_rendering_options(atom_type=o_type)
     assert o_atom_options == {"radius": 0.2}
 
@@ -86,7 +86,7 @@ def test_renderer_helper_ctp_system(capped_trigonal_prism_solv_system):
     render_rep.add_atom(
         "center", fe_type, color=None, actor_name="fe", label=None
     )  # Handle atom_tag='center' for solvation center! TODO
-    assert render_rep.num_atoms == 1
+    assert render_rep.atoms.num_atoms == 1
     # Loop through the solvation atoms and add them
     for i, solv_atom in enumerate(capped_trigonal_prism_solv_system.atoms):
         iatom_type = solv_atom.number
@@ -94,11 +94,13 @@ def test_renderer_helper_ctp_system(capped_trigonal_prism_solv_system):
         render_rep.add_atom(iatom_tag, iatom_type)
 
     # There should be 8 atoms in the renderer represenation
-    assert render_rep.num_atoms == len(capped_trigonal_prism_solv_system.atoms) + 1
+    assert (
+        render_rep.atoms.num_atoms == len(capped_trigonal_prism_solv_system.atoms) + 1
+    )
 
     # Retreive the indices and coord using atom tags from the solvation shell object
-    for i, name in enumerate(render_rep.atoms.keys()):
-        tag = render_rep.get_tag_from_atom_name(name)
+    for i, atom in enumerate(render_rep.atoms.atoms):
+        tag = atom.tag
         if tag == "center":
             coord = capped_trigonal_prism_solv_system.center
         else:
@@ -110,13 +112,13 @@ def test_renderer_helper_ctp_system(capped_trigonal_prism_solv_system):
             coord = capped_trigonal_prism_solv_system.atoms.get_positions()[index]
 
     # Change the colour of the furthest solvent atom to red
-    seventh_mol_name = list(render_rep.atoms.keys())[-1]
+    seventh_mol_name = render_rep.atoms.atoms[-1].name
     render_rep.update_atom_color(seventh_mol_name, color="red")
     seventh_mol_options = render_rep.get_render_info_from_atom_name(seventh_mol_name)
     assert seventh_mol_options == {"radius": 0.2}
     # Check that you can access the new color of this atom from the atom tag
     # This can be used for getting bond colors
-    seventh_mol_tag = render_rep.atoms.get(seventh_mol_name).get("tag")
+    seventh_mol_tag = render_rep.atoms.atoms[-1].tag
     seventh_mol_color = render_rep.find_color_by_atom_tag(seventh_mol_tag)
     assert seventh_mol_color == "red"
 
@@ -139,7 +141,7 @@ def test_renderer_helper_ctp_system(capped_trigonal_prism_solv_system):
 
     # Add a bond type color
     render_rep.add_bond_type_rendering(bond_type=assigned_bond_type, color="dimgrey")
-    assert render_rep.bond_type_rendering[assigned_bond_type].get("color") == "dimgrey"
+    assert render_rep.bond_type_rendering[assigned_bond_type].color == "dimgrey"
 
     # Add a bond between the first and second atoms, coloured according to the bond_type color
     tag3 = capped_trigonal_prism_solv_system.atoms[1].tag
@@ -174,9 +176,9 @@ def test_renderer_helper_ctp_system(capped_trigonal_prism_solv_system):
     assert render_rep.hulls["hull_1"].get("color") == "skyblue"
 
     # Test that you can delete things from the RendererRepresentation object
-    assert "fe" in render_rep.atoms.keys()
+    assert render_rep.atoms.find_atom_with_name("fe")
     render_rep.delete_atom("fe")
-    assert "fe" not in render_rep.atoms.keys()
+    assert render_rep.atoms.find_atom_with_name("fe") is None
     # Delete the bonds
     render_rep.delete_bond("bond_1")
     render_rep.delete_bond("bond_2")
@@ -225,10 +227,12 @@ def test_renderer_helper_populate(capped_trigonal_prism_solv_system):
         render_rep, capped_trigonal_prism_solv_system, include_center=True
     )
     # There should be 8 atoms in the renderer represenation
-    assert render_rep.num_atoms == len(capped_trigonal_prism_solv_system.atoms) + 1
+    assert (
+        render_rep.atoms.num_atoms == len(capped_trigonal_prism_solv_system.atoms) + 1
+    )
 
     # Change the colour of the seventh atom
-    seventh_mol_name = list(render_rep.atoms.keys())[-1]
+    seventh_mol_name = render_rep.atoms.atoms[-1].name
     render_rep.update_atom_color(seventh_mol_name, color="red")
     seventh_mol_options = render_rep.get_render_info_from_atom_name(seventh_mol_name)
 

--- a/tests/test_renderer_representation.py
+++ b/tests/test_renderer_representation.py
@@ -1,9 +1,9 @@
 import pytest
 import numpy as np
 from ase.io import read
-from ase.atoms import Atom, Atoms
 from ase.data import chemical_symbols
 from pathlib import Path
+import warnings
 
 import solvis
 
@@ -40,6 +40,7 @@ def capped_trigonal_prism_solv_system():
     return solvation_shell
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_renderer_helper_ctp_system(capped_trigonal_prism_solv_system):
     """
     Test that the RendererRepresentation can accurately describe elements required for plotting.


### PR DESCRIPTION
The following major changes have been implemented:

1. Type hints added 

2. The `RendererRepresentation` object has been modified. Instead of handling the atoms as a nested dictionary, now there is an `AllAtomInfo` class, which contains a list of `SingleAtomInfo` objects (which hold the rendering options, color etc). The `AllAtomInfo` class also handles the naming of actors itself, which was previously handled by the `RendererRepresentation` class. 

3. Atom and bond type information are handled by a class called `RenderingUnitTypeInfo`
4. Bug fix in code for finding all hydrogen bonds
5. Added the new functions `get_center_actor_name_from_type` in `RendererRepresentation` and `find_first_atom_with_type` in `AllAtomInfo`.