### PR TITLE
Upload to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # solvis
 
-<img src="https://github.com/amritagos/solvis/blob/main/branding/logo/logo.png" width="300" />
+<img src="https://github.com/amritagos/solvis/blob/main/branding/logo/logo.png?raw=true" width="300" />
 
 ## About
 
 Various ways to analyze and visualize solvation shell structures, which wraps [`PyVista`](https://docs.pyvista.org/version/stable/). Meant primarily for analyzing the outputs produced by LAMMPS here. 
 
-## Installation
+## Installation 
+
+### From PyPI
+
+You can install `solvis` from PyPI like so: 
+
+```bash
+pip install solvis-tools
+```
+
+### From source
 
 We use [`micromamba`](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html) as the package manager, but feel free to use your own poison. Create and activate the environment. 
 
@@ -48,10 +58,10 @@ pytest --cov=solvis tests/
 
 ## Image Gallery
 <p float="left">
-    <img src="https://github.com/amritagos/solvis/blob/main/resources/non_octahedral_shape.png" width="200" />
-    <img src="https://github.com/amritagos/solvis/blob/main/resources/octahedral_shell.png" width="200" />
+    <img src="https://github.com/amritagos/solvis/blob/main/resources/non_octahedral_shape.png?raw=true" width="200" />
+    <img src="https://github.com/amritagos/solvis/blob/main/resources/octahedral_shell.png?raw=true" width="200" />
 </p>
 <p float="left">
-    <img src="https://github.com/amritagos/solvis/blob/main/resources/shell_with_hbonds.png" width="200" />
-    <img src="https://github.com/amritagos/solvis/blob/main/resources/hbond_non_oct.png" width="200" />
+    <img src="https://github.com/amritagos/solvis/blob/main/resources/shell_with_hbonds.png?raw=true" width="200" />
+    <img src="https://github.com/amritagos/solvis/blob/main/resources/hbond_non_oct.png?raw=true" width="200" />
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # solvis
 
-<img src="branding/logo/logo.png" width="300" />
+<img src="https://github.com/amritagos/solvis/blob/main/branding/logo/logo.png" width="300" />
 
 ## About
 
@@ -48,10 +48,10 @@ pytest --cov=solvis tests/
 
 ## Image Gallery
 <p float="left">
-    <img src="resources/non_octahedral_shape.png" width="200" />
-    <img src="resources/octahedral_shell.png" width="200" />
+    <img src="https://github.com/amritagos/solvis/blob/main/resources/non_octahedral_shape.png" width="200" />
+    <img src="https://github.com/amritagos/solvis/blob/main/resources/octahedral_shell.png" width="200" />
 </p>
 <p float="left">
-    <img src="resources/shell_with_hbonds.png" width="200" />
-    <img src="resources/hbond_non_oct.png" width="200" />
+    <img src="https://github.com/amritagos/solvis/blob/main/resources/shell_with_hbonds.png" width="200" />
+    <img src="https://github.com/amritagos/solvis/blob/main/resources/hbond_non_oct.png" width="200" />
 </p>

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - python==3.10
   - ase==3.22.1
   - numpy==1.22.4
-  - scipy==1.7.3
+  - scipy>=1.7.3
   - ipython>=8.26.0
   - pandas>=2.2.2
   - pyvista==0.43.0

--- a/environment.yml
+++ b/environment.yml
@@ -10,9 +10,10 @@ channels:
 #     - {{ compiler('c') }}
 #     - {{ compiler('c++') }}
 dependencies:
-  - python==3.10
-  - ase==3.22.1
-  - numpy==1.22.4
+  - python>=3.10
+  - build<0.10.0
+  - ase>=3.22.1
+  - numpy>=1.26.4 # 1.22.4
   - scipy>=1.7.3
   - ipython>=8.26.0
   - pandas>=2.2.2
@@ -25,6 +26,7 @@ dependencies:
   - pooch==1.8.0
   - scooby==0.9.2
   # Packaging
+  - twine
   - flit==3.9.0
   - pytest==6.2.5
   - coverage==6.1.1
@@ -37,6 +39,6 @@ dependencies:
   - flake8-docstrings==1.6.0 
   - meson-python>=0.16.0
   - pytest-cov>=3.0.0
-  - pip:
-    # works for regular pip packages
-    - lammps-logfile
+  # - pip:
+  #   # works for regular pip packages
+  #   - lammps-logfile

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('solvis')
 
 py_mod = import('python')
-py = py_mod.find_installation(pure: false)
+py = py_mod.find_installation(pure: true) # This is pure Python, so maybe this should be true
 
 # solvis, main package
 py.install_sources([
@@ -16,6 +16,6 @@ py.install_sources([
     'solvis/vis_initializers.py',
     'solvis/visualization.py'
   ],
-  pure: false, # install next to compiled extension
+  pure: true, # no compiled extension
   subdir: 'solvis'
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "mesonpy"
 # Important, tells pip how to install the package
 
 [project]
-name = "solvis"
+name = "solvis-tools"
 version = "0.0.1"
-description = "A module for analyzing and visualizing solvation shells in LAMMPS output files."
+description = "A module for analyzing and visualizing solvation shells in LAMMPS output files, but would work with most files that can be handled by ASE."
 authors = [
     {name = "Amrita Goswami", email = "amrita@hi.is"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ description = "A module for analyzing and visualizing solvation shells in LAMMPS
 authors = [
     {name = "Amrita Goswami", email = "amrita@hi.is"},
 ]
+classifiers=[
+        'Programming Language :: Python :: 3.3']
 dependencies = [
     "ase == 3.22.1",
     "numpy == 1.22.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "mesonpy"
 
 [project]
 name = "solvis-tools"
-version = "0.1.1"
+version = "0.1.4"
 description = "A module for analyzing and visualizing solvation shells in LAMMPS output files, but would work with most files that can be handled by ASE."
 authors = [
     {name = "Amrita Goswami", email = "amrita@hi.is"},
@@ -14,7 +14,7 @@ classifiers=[
         'Programming Language :: Python :: 3.10']
 dependencies = [
     "ase == 3.22.1",
-    "numpy == 1.22.4",
+    "numpy",
     "scipy >= 1.7.3",
     "pyvista == 0.43.0",
     "pillow == 10.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,27 +1,27 @@
 [build-system]
-requires = ["meson-python"]
+requires = ["meson-python>=0.16.0"]
 build-backend = "mesonpy"
 # Important, tells pip how to install the package
 
 [project]
 name = "solvis-tools"
-version = "0.0.1"
+version = "0.1.1"
 description = "A module for analyzing and visualizing solvation shells in LAMMPS output files, but would work with most files that can be handled by ASE."
 authors = [
     {name = "Amrita Goswami", email = "amrita@hi.is"},
 ]
 classifiers=[
-        'Programming Language :: Python :: 3.3']
+        'Programming Language :: Python :: 3.10']
 dependencies = [
     "ase == 3.22.1",
     "numpy == 1.22.4",
-    "scipy == 1.7.3",
+    "scipy >= 1.7.3",
     "pyvista == 0.43.0",
     "pillow == 10.0.1",
     "imageio == 2.31.5",
     "pooch==1.8.0",
     "scooby==0.9.2"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}
 

--- a/solvis/visualization.py
+++ b/solvis/visualization.py
@@ -4,7 +4,6 @@ import numpy as np
 from scipy.spatial import ConvexHull, Delaunay
 from scipy.spatial import KDTree
 import math
-import pandas as pd
 from pathlib import Path
 from pyvista import PolyData
 import pyvista as pv


### PR DESCRIPTION
- Changed the `environment.yml` file to include dependencies (`twine`). Currently, `python3 -m build` does not work unless you get a version of `build` which is less than 0.10.0. Therefore, this was changed in the `environment.yml` file as well.
- Removed unused `pandas` import that was causing PyPI downloaded `solvis` to break.
- `solvis` can be installed from PyPI (name: `solvis-tools`). 
- Changed URLs in the README so that they show up on PyPI.